### PR TITLE
Replace tabs and avoid redundant newlines in pdf parsing

### DIFF
--- a/text_from_ebook.py
+++ b/text_from_ebook.py
@@ -40,10 +40,10 @@ def epub_to_text(epub_path):
 
 def pdf_to_text(pdf_path):
     reader = PdfReader(pdf_path)
-    text = ""
+    pages = []
     for page in reader.pages:
-        text += page.extract_text()
-    return text
+        page_text = re.sub(r"\t", " ", page.extract_text())
+    return "\n".join(pages)
 
 
 def clean_text(text):


### PR DESCRIPTION
- A recent change introduced redundant newlines when parsing pdfs. This commit reverts that change.
- Some parsed pdfs have a lot of tab chars, putting the text in columns. This is redeemed by substitution.

Columns:
![image](https://github.com/user-attachments/assets/763e91fa-589a-4f4a-a5e9-6fe074b47e3b)

Redundant newlines:
![image](https://github.com/user-attachments/assets/83ef3b4a-e64c-4fd7-b9d0-dd8034787947)

Result after fixes:
![image](https://github.com/user-attachments/assets/cfa46547-8902-4e14-945b-ef6555cc2581)
